### PR TITLE
Fix constants typo and reset EditTaskDialog state

### DIFF
--- a/src/FAB/FAB.js
+++ b/src/FAB/FAB.js
@@ -15,7 +15,7 @@ import NewIdeaDialog from './NewIdeaDialog';
 import calculateBottom from './lib/calculateBottom';
 
 import {
-  FABRaiseWindowWidthTreshold,
+  FABRaiseWindowWidthThreshold,
   FABBottom,
   FABRaisedBottom,
   FABMiniRaisedBottomClosed,
@@ -83,7 +83,7 @@ class FAB extends Component {
       plusFAB: {
         position: 'absolute',
         right: FABRight,
-        bottom: this.props.FABRaised && this.props.width < FABRaiseWindowWidthTreshold ?
+        bottom: this.props.FABRaised && this.props.width < FABRaiseWindowWidthThreshold ?
           FABRaisedBottom :
           FABBottom,
         transform: this.state.FABOpen ? 'rotate(45deg)' : 'rotate(0)',
@@ -93,7 +93,7 @@ class FAB extends Component {
       doneFAB: {
         position: 'absolute',
         right: FABMiniRight,
-        bottom: this.props.FABRaised && this.props.width < FABRaiseWindowWidthTreshold ?
+        bottom: this.props.FABRaised && this.props.width < FABRaiseWindowWidthThreshold ?
           FABMiniRaisedBottomClosed :
           calculateBottom(this.state.FABOpen, 0),
         opacity: this.state.FABOpen ? 1 : 0,
@@ -103,7 +103,7 @@ class FAB extends Component {
       lightbulbFAB: {
         position: 'absolute',
         right: FABMiniRight,
-        bottom: this.props.FABRaised && this.props.width < FABRaiseWindowWidthTreshold ?
+        bottom: this.props.FABRaised && this.props.width < FABRaiseWindowWidthThreshold ?
           FABMiniRaisedBottomClosed :
           calculateBottom(this.state.FABOpen, 1),
         opacity: this.state.FABOpen ? 1 : 0,

--- a/src/Task/EditTaskDialog.js
+++ b/src/Task/EditTaskDialog.js
@@ -7,6 +7,15 @@ import { HotKeys } from 'react-hotkeys';
 
 class EditTaskDialog extends Component {
   state = { task: this.props.task };
+
+  componentWillReceiveProps(nextProps) {
+    if (!nextProps.open) {
+      this.setState({ task: '' });
+    } else if (nextProps.task !== this.props.task) {
+      this.setState({ task: nextProps.task });
+    }
+  }
+
   keyMap = { confirmEditTask: 'enter' };
 
   handleTaskChange = (e) => {
@@ -15,6 +24,7 @@ class EditTaskDialog extends Component {
     });
   }
   handleRequestClose = () => {
+    this.setState({ task: '' });
     this.props.onRequestClose();
   }
   handleRequestEdit = () => {
@@ -74,7 +84,7 @@ class EditTaskDialog extends Component {
             fullWidth
             underlineFocusStyle={textFieldStyles.underlineFocusStyle}
             floatingLabelFocusStyle={textFieldStyles.floatingLabelFocusStyle}
-            defaultValue={this.props.task}
+            value={this.state.task}
             onChange={this.handleTaskChange}
             autoFocus
           />

--- a/src/Task/__tests__/EditTaskDialog.spec.js
+++ b/src/Task/__tests__/EditTaskDialog.spec.js
@@ -26,11 +26,11 @@ it('should set Dialog open based on props', () => {
   const wrapper = getActualDialog({ open: true });
   expect(wrapper.find('Dialog').prop('open')).toBe(true);
 });
-it('should set TextField defaultValue based on props', () => {
+it('should set TextField value based on props', () => {
   const wrapper = getActualDialog({
     task: 'a cool task',
   });
-  expect(wrapper.find('TextField').prop('defaultValue')).toBe('a cool task');
+  expect(wrapper.find('TextField').prop('value')).toBe('a cool task');
 });
 it('should call onRequestClose inside close FlatButton onClick', (done) => {
   const wrapper = getActualDialog({
@@ -54,4 +54,11 @@ it('should set FlatButton disabled based on state', () => {
   wrapper.find('TextField').props().onChange({ target: { value: 'a cool task' } });
   wrapper.update();
   expect(wrapper.find('Dialog').prop('actions')[0].props.disabled).toBe(false);
+});
+
+it('should reset state.task when dialog is closed', () => {
+  const wrapper = getActualDialog({ open: true, task: 'task 1' });
+  wrapper.find('TextField').props().onChange({ target: { value: 'edited' } });
+  wrapper.find('Dialog').prop('actions')[1].props.onClick();
+  expect(wrapper.state('task')).toBe('');
 });

--- a/src/Task/lib/__tests__/classify.spec.js
+++ b/src/Task/lib/__tests__/classify.spec.js
@@ -67,7 +67,7 @@ it('should set overdue tasks signal to true', () => {
   const { overdue } = classify(tasks);
   expect(overdue[0].signal).toBe(true);
 });
-it('should set not-yet tasks color to red', () => {
+it('should set not-yet tasks color to teal', () => {
   const { notYet } = classify(tasks);
   expect(notYet[0].color).toBe('hsl(180, 100%, 50%)');
 });
@@ -75,7 +75,7 @@ it('should set not-yet tasks signal to false', () => {
   const { notYet } = classify(tasks);
   expect(notYet[0].signal).toBe(false);
 });
-it('should set done tasks color to red', () => {
+it('should set done tasks color to purple', () => {
   const { done } = classify(tasks);
   expect(done[0].color).toBe('#AB47BC');
 });

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,4 +1,4 @@
-export const FABRaiseWindowWidthTreshold = 768;
+export const FABRaiseWindowWidthThreshold = 768;
 export const FABBottom = 24;
 export const FABMiniBottomClosed = 32;
 export const FABRaisedBottom = 72;


### PR DESCRIPTION
## Summary
- fix constant typo `FABRaiseWindowWidthThreshold`
- reset `EditTaskDialog` state when closing and when props change
- make `EditTaskDialog` use controlled `TextField`
- correct misleading color descriptions in `classify.spec.js`
- add a regression test for resetting EditTaskDialog state

## Testing
- `yarn test`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68409b2a24fc8333984ce635df586347